### PR TITLE
Fixes #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 gtest/
+.vscode/
 GPATH
 GRTAGS
 GTAGS

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,14 +21,7 @@
                 }
             ],
             "externalConsole": false,
-            "MIMode": "lldb",
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                }
-            ]
+            "MIMode": "lldb"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "ostream": "cpp",
         "string": "cpp",
         "iostream": "cpp",
-        "fstream": "cpp"
+        "fstream": "cpp",
+        "algorithm": "cpp"
     }
 }

--- a/include/csvrow.h
+++ b/include/csvrow.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
+#include <cctype>
 
 #include "vtterror.h"
 #include "errcode.h"

--- a/src/csvrow.cpp
+++ b/src/csvrow.cpp
@@ -66,7 +66,8 @@ vector<string> CSVRow::getNextLineAndSplitIntoTokens(string &line)
 {
     vector<string> result;
 
-    /* Only do things with this line if it has at least three elements and if it starts with a timestamp. 
+    /* 
+    Only do things with this line if it has at least three elements and if it starts with a timestamp. 
     This should skip invalid lines.
     */
     stringstream lineStream(line);
@@ -77,20 +78,19 @@ vector<string> CSVRow::getNextLineAndSplitIntoTokens(string &line)
     {
         while (getline(lineStream, cell, ','))
         {
-            result.push_back(cell);
+            /*
+            Handle trailing commas with no data after them by checking if a split string only contains white spaces.
+            This will make it so that only parts after a comma that actually contain text will be written to the VTT. 
+            */
+            bool whiteSpacesOnly = all_of(cell.begin(), cell.end(), ::isspace);
+            if (!whiteSpacesOnly)
+                result.push_back(cell);
         }
     }
     else
     {
         // This text contains double quotes, meaning there must be commas in the caption text.
         handleCommaText(line, result);
-    }
-
-    // This checks for a trailing comma with no data after it.
-    if (!lineStream && cell.empty())
-    {
-        // If there was a trailing comma then add an empty element.
-        result.push_back("");
     }
 
     return result;


### PR DESCRIPTION
It turns out the trailing commas were the culprit! Since the program splits lines based on commas, I added an extra check for if a piece of the line is only white space. Anything fitting these criteria will be skipped, ensuring that only parts actually containing text will be written.

This fixes it because CSVRow pulls text for the caption from the back of the vector that contains the split pieces. Trailing commas would make it so that white space was at the end of a row, meaning the text would erroneously become a white space.